### PR TITLE
Add threading support for the `video` command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,9 @@ enum Commands {
         distorted: PathBuf,
 
         /// How many worker threads to use for decoding & calculating scores.
+        /// Note: Memory usage increases linearly with the number of workers.
         #[arg(long, short)]
-        threads: Option<usize>,
+        frame_threads: Option<usize>,
 
         /// Whether to output a frame-by-frame graph of scores.
         #[arg(long, short)]
@@ -93,7 +94,7 @@ fn main() {
         Commands::Video {
             source,
             distorted,
-            threads,
+            frame_threads,
             graph,
             verbose,
             src_matrix,
@@ -105,7 +106,7 @@ fn main() {
             dst_primaries,
             dst_full_range,
         } => {
-            let threads = threads.unwrap_or(1).max(1);
+            let frame_threads = frame_threads.unwrap_or(1).max(1);
             let src_matrix = src_matrix
                 .map(|i| parse_matrix(&i))
                 .unwrap_or(MatrixCoefficients::Unspecified);
@@ -127,7 +128,7 @@ fn main() {
             compare_videos(
                 &source,
                 &distorted,
-                threads,
+                frame_threads,
                 graph,
                 verbose,
                 src_matrix,

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,10 @@ enum Commands {
         #[arg(help = "Distorted video", value_hint = clap::ValueHint::FilePath)]
         distorted: PathBuf,
 
+        /// How many worker threads to use for decoding & calculating scores.
+        #[arg(long, short)]
+        threads: Option<usize>,
+
         /// Whether to output a frame-by-frame graph of scores.
         #[arg(long, short)]
         graph: bool,
@@ -89,6 +93,7 @@ fn main() {
         Commands::Video {
             source,
             distorted,
+            threads,
             graph,
             verbose,
             src_matrix,
@@ -100,6 +105,7 @@ fn main() {
             dst_primaries,
             dst_full_range,
         } => {
+            let threads = threads.unwrap_or(1).max(1);
             let src_matrix = src_matrix
                 .map(|i| parse_matrix(&i))
                 .unwrap_or(MatrixCoefficients::Unspecified);
@@ -121,6 +127,7 @@ fn main() {
             compare_videos(
                 &source,
                 &distorted,
+                threads,
                 graph,
                 verbose,
                 src_matrix,

--- a/src/video.rs
+++ b/src/video.rs
@@ -1,23 +1,47 @@
-use av_metrics_decoders::{Decoder, FfmpegDecoder};
+use av_metrics_decoders::{Decoder, FfmpegDecoder, Pixel, Frame};
 use crossterm::tty::IsTty;
 use image::ColorType;
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::{ProgressBar, ProgressStyle, ProgressState};
 use num_traits::FromPrimitive;
 use ssimulacra2::{
-    compute_frame_ssimulacra2, ColorPrimaries, MatrixCoefficients, Rgb, TransferCharacteristic,
-    Yuv, YuvConfig,
+    compute_frame_ssimulacra2, ColorPrimaries, MatrixCoefficients, TransferCharacteristic,
+    Yuv, YuvConfig, LinearRgb,
 };
 use statrs::statistics::{Data, Distribution, Median, OrderStatistics};
 use std::io::stderr;
+use std::sync::{Mutex, Arc, mpsc};
 use std::{
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
 
+fn calc_score<S: Pixel, D: Pixel>(mtx: &Mutex<(FfmpegDecoder, FfmpegDecoder)>, src_yuvcfg: &YuvConfig, dst_yuvcfg: &YuvConfig) -> Option<f64> {
+    let (src_frame, dst_frame) = {
+        let mut guard = mtx.lock().unwrap();
+        let src_frame = guard.0.read_video_frame::<S>();
+        let dst_frame = guard.1.read_video_frame::<D>();
+
+        if let (Some(sf), Some(df)) = (src_frame, dst_frame) {
+            (sf, df)
+        } else {
+            return None
+        }
+    };
+
+    let src_yuv = Yuv::new(src_frame, *src_yuvcfg).unwrap();
+    let dst_yuv = Yuv::new(dst_frame, *dst_yuvcfg).unwrap();
+
+    Some(
+        compute_frame_ssimulacra2(src_yuv, dst_yuv)
+            .expect("Failed to calculate ssimulacra2")
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn compare_videos(
     source: &Path,
     distorted: &Path,
+    threads: usize,
     graph: bool,
     verbose: bool,
     mut src_matrix: MatrixCoefficients,
@@ -29,19 +53,8 @@ pub fn compare_videos(
     mut dst_primaries: ColorPrimaries,
     dst_full_range: bool,
 ) {
-    let progress = if stderr().is_tty() {
-        ProgressBar::new_spinner().with_style(
-            ProgressStyle::with_template(
-                "[{elapsed_precise:.blue}] [{per_sec:.green}] Frame {pos}",
-            )
-            .unwrap(),
-        )
-    } else {
-        ProgressBar::hidden()
-    };
-
-    let mut source = FfmpegDecoder::new(source).unwrap();
-    let mut distorted = FfmpegDecoder::new(distorted).unwrap();
+    let source = FfmpegDecoder::new(source).unwrap();
+    let distorted = FfmpegDecoder::new(distorted).unwrap();
 
     if src_matrix == MatrixCoefficients::Unspecified {
         src_matrix = guess_matrix_coefficients(
@@ -105,67 +118,65 @@ pub fn compare_videos(
         color_primaries: dst_primaries,
     };
 
+    let (result_tx, result_rx) = mpsc::channel();
+    let src_bd = source.get_bit_depth();
+    let dst_bd = distorted.get_bit_depth();
+
+    let decoders = Arc::new(Mutex::new((source, distorted)));
+    for _ in 0..threads {
+        let decoders = Arc::clone(&decoders);
+        let result_tx = result_tx.clone();
+
+        std::thread::spawn(move || {
+            loop {
+                let score = match (src_bd, dst_bd) {
+                    (8, 8) => calc_score::<u8, u8>(&decoders, &src_config, &dst_config),
+                    (8, _) => calc_score::<u8, u16>(&decoders, &src_config, &dst_config),
+                    (_, 8) => calc_score::<u16, u8>(&decoders, &src_config, &dst_config),
+                    (_, _) => calc_score::<u16, u16>(&decoders, &src_config, &dst_config),
+                };
+
+                if let Some(result) = score {
+                    result_tx.send(result).unwrap();
+                } else {
+                    // no score = no more frames to read
+                    break;
+                }
+            }
+        });
+    }
+
+    // Needs to be dropped or the main thread never stops waiting for scores
+    drop(result_tx);
+
     let mut results = Vec::new();
     let mut frame = 0usize;
-    loop {
-        let (src_rgb, dst_rgb) = match (source.get_bit_depth(), distorted.get_bit_depth()) {
-            (8, 8) => {
-                let src_frame = source.read_video_frame::<u8>();
-                let dst_frame = distorted.read_video_frame::<u8>();
-                if let (Some(src_frame), Some(dst_frame)) = (src_frame, dst_frame) {
-                    let src = Yuv::new(src_frame, src_config).unwrap();
-                    let dst = Yuv::new(dst_frame, dst_config).unwrap();
-                    (Rgb::try_from(src).unwrap(), Rgb::try_from(dst).unwrap())
-                } else {
-                    break;
-                }
-            }
-            (8, _) => {
-                let src_frame = source.read_video_frame::<u8>();
-                let dst_frame = distorted.read_video_frame::<u16>();
-                if let (Some(src_frame), Some(dst_frame)) = (src_frame, dst_frame) {
-                    let src = Yuv::new(src_frame, src_config).unwrap();
-                    let dst = Yuv::new(dst_frame, dst_config).unwrap();
-                    (Rgb::try_from(src).unwrap(), Rgb::try_from(dst).unwrap())
-                } else {
-                    break;
-                }
-            }
-            (_, 8) => {
-                let src_frame = source.read_video_frame::<u16>();
-                let dst_frame = distorted.read_video_frame::<u8>();
-                if let (Some(src_frame), Some(dst_frame)) = (src_frame, dst_frame) {
-                    let src = Yuv::new(src_frame, src_config).unwrap();
-                    let dst = Yuv::new(dst_frame, dst_config).unwrap();
-                    (Rgb::try_from(src).unwrap(), Rgb::try_from(dst).unwrap())
-                } else {
-                    break;
-                }
-            }
-            (_, _) => {
-                let src_frame = source.read_video_frame::<u16>();
-                let dst_frame = distorted.read_video_frame::<u16>();
-                if let (Some(src_frame), Some(dst_frame)) = (src_frame, dst_frame) {
-                    let src = Yuv::new(src_frame, src_config).unwrap();
-                    let dst = Yuv::new(dst_frame, dst_config).unwrap();
-                    (Rgb::try_from(src).unwrap(), Rgb::try_from(dst).unwrap())
-                } else {
-                    break;
-                }
-            }
-        };
 
-        let result =
-            compute_frame_ssimulacra2(src_rgb, dst_rgb).expect("Failed to calculate ssimulacra2");
-        if verbose {
-            println!("Frame {frame}: {result:.8}");
-        }
-        results.push(result);
+    let progress = if stderr().is_tty() {
+        ProgressBar::new_spinner().with_style(
+            ProgressStyle::with_template(
+                "[{elapsed_precise:.blue}] [{per_sec:.green}] Frame {pos}",
+            )
+            .unwrap()
+            .with_key("per_sec", |s: &ProgressState, w: &mut dyn std::fmt::Write|
+                write!(w, "{:5.02} FPS", s.per_sec()).unwrap()
+            )
+            .with_key("pos", |s: &ProgressState, w: &mut dyn std::fmt::Write|
+                write!(w, "{:6}", s.pos()).unwrap()
+            ),
+        )
+    } else {
+        ProgressBar::hidden()
+    };
+
+    for score in result_rx {
+        results.push(score);
         frame += 1;
         progress.inc(1);
     }
 
     progress.finish();
+
     let mut data = Data::new(results.clone());
     println!("Video Score for {} frames", frame);
     println!("Mean: {:.8}", data.mean().unwrap());

--- a/src/video.rs
+++ b/src/video.rs
@@ -159,11 +159,8 @@ pub fn compare_videos(
             )
             .unwrap()
             .with_key("per_sec", |s: &ProgressState, w: &mut dyn std::fmt::Write|
-                write!(w, "{:5.02} FPS", s.per_sec()).unwrap()
+                write!(w, "{:5.02} fps", s.per_sec()).unwrap()
             )
-            .with_key("pos", |s: &ProgressState, w: &mut dyn std::fmt::Write|
-                write!(w, "{:6}", s.pos()).unwrap()
-            ),
         )
     } else {
         ProgressBar::hidden()

--- a/src/video.rs
+++ b/src/video.rs
@@ -41,7 +41,7 @@ fn calc_score<S: Pixel, D: Pixel>(mtx: &Mutex<(FfmpegDecoder, FfmpegDecoder)>, s
 pub fn compare_videos(
     source: &Path,
     distorted: &Path,
-    threads: usize,
+    frame_threads: usize,
     graph: bool,
     verbose: bool,
     mut src_matrix: MatrixCoefficients,
@@ -123,7 +123,7 @@ pub fn compare_videos(
     let dst_bd = distorted.get_bit_depth();
 
     let decoders = Arc::new(Mutex::new((source, distorted)));
-    for _ in 0..threads {
+    for _ in 0..frame_threads {
         let decoders = Arc::clone(&decoders);
         let result_tx = result_tx.clone();
 


### PR DESCRIPTION
The basic idea is that we hide the two decoders behind a `Mutex`, and let the worker threads decode two frames (one per decoder) to calculate the SSIMU2 score. It's written so that the Mutex lock is dropped as quickly as possible after decoding the frames, so another worker thread can start decoding ASAP. The resulting score value is sent via `result_tx` to `result_rx`, which is used in the main thread to accumulate the scores and handle the terminal output.

Some notes:
- I've tested a few approaches to multithreading, but it looks like there's always some memory bottleneck which is hit somewhere between 4 and 5 worker threads on my machine. I've "confirmed" it's a memory bottleneck by downclocking my RAM, which significantly reduced the performance ceiling.
- With every thread holding up to 2 frames at a time, it's very easy to hit OOM if you just enter a high `threads` value. I've thought about clamping the parameter to something like `(1, 20)` but then decided against it, as this is a user error.
- Minor point but I'm not sure if I should avoid using `drop` like that. Other languages with "automatic" memory management generally discourage manual deletion of variables. There's other ways to drop the value (move some of the code into a new scope, for example) but this seemed to be the easiest and most obvious way