### PR TITLE
Expand the Arch requirements a little.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Binary interface to the Rust implementation of the SSIMULACRA2 metric: https://g
 ### Arch
 
 ```bash
-sudo pacman -S vapoursynth vapoursynth-plugin-lsmashsource gcc make cmake pkg-config # Keep install dependencies
+sudo pacman -S vapoursynth vapoursynth-plugin-lsmashsource gcc make cmake pkg-config ttf-bitstream-vera # Keep install dependencies
 ```
 
 ### Other Linux

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Binary interface to the Rust implementation of the SSIMULACRA2 metric: https://g
 ### Arch
 
 ```bash
-sudo pacman -S vapoursynth vapoursynth-plugin-lsmashsource # Keep install dependencies
+sudo pacman -S vapoursynth vapoursynth-plugin-lsmashsource gcc make cmake pkg-config # Keep install dependencies
 ```
 
 ### Other Linux


### PR DESCRIPTION
I installed a completely fresh install of Arch and this crate was the first thing I actually wanted to install I found I was missing some basic stuff in my original command. 

Typically these would be installed by other packages in the course of setting up the OS but having them here will make it easier to install on a more bare server-like system like I set up.