### PR TITLE
Add note about l-smash source for Linux build

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ sudo pacman -S vapoursynth vapoursynth-plugin-lsmashsource gcc make cmake pkg-co
 
 See http://www.vapoursynth.com/doc/installation.html#linux-installation
 
-TODO: How to install LSMASHSource?
+Install LSMASHSource from https://github.com/AkarinVS/L-SMASH-Works
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ sudo pacman -S vapoursynth vapoursynth-plugin-lsmashsource gcc make cmake pkg-co
 
 See http://www.vapoursynth.com/doc/installation.html#linux-installation
 
-Install LSMASHSource from https://github.com/AkarinVS/L-SMASH-Works
+Install l-smash from https://github.com/l-smash/l-smash
+Install LSMASHSource VapourSynth plugin from https://github.com/AkarinVS/L-SMASH-Works
 
 ### Windows
 


### PR DESCRIPTION
Just a quick change to note where to get l-smash and LSMASHSource VapourSynth plugin source for other Linux distros that do not package it (Debian).

I didn't include build instructions, but I can add that if we think it's helpful. 