### PR TITLE
Disable ssimulacra2's rayon feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,6 @@ dependencies = [
  "anyhow",
  "nalgebra 0.32.2",
  "num-traits",
- "rayon",
  "wide",
  "yuvxyb",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ clap = { version = "4.0.18", features = ["derive"] }
 crossterm = "0.26.1"
 indicatif = "0.17.1"
 num-traits = { version = "0.2.15", optional = true }
-ssimulacra2 = "0.4.0"
+ssimulacra2 = { version = "0.4.0", default-features = false }
 statrs = { version = "0.16.0", optional = true }
 
 [dependencies.image]


### PR DESCRIPTION
Closes #21.

We have our own threading mechanism, adding rayon on top of that is unnecessary and less efficient[^1].

This also makes the CPU usage a lot more predictable. Using `-f 8` on a machine with 16 logical cores will show close to 50% CPU usage. With rayon, this was always more than expected (~70% in this example).

[^1]: On my two machines, normalizing for CPU usage will always result in higher FPS without rayon.