### PR TITLE
Add start frame and frames option to video comparison

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,9 +47,9 @@ enum Commands {
         frame_threads: Option<usize>,
 
         /// Frame to start comparison at.
-        /// 1 is the first frame.
-        #[arg(long, short)]
-        start: Option<usize>,
+        /// 
+        #[arg(long, short, default_value_t = 0)]
+        start: usize,
 
         /// How many frames to compare.
         /// If left unspecified, all frames will be compared.

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,16 @@ enum Commands {
         #[arg(long, short)]
         frame_threads: Option<usize>,
 
+        /// Frame to start comparison at.
+        /// 1 is the first frame.
+        #[arg(long, short)]
+        start: Option<usize>,
+
+        /// How many frames to compare.
+        /// If left unspecified, all frames will be compared.
+        #[arg(long)]
+        frames: Option<usize>,
+
         /// How to increment current frame count; e.g. 10 will read every 10th frame.
         #[arg(long, short)]
         increment: Option<usize>,
@@ -99,6 +109,8 @@ fn main() {
             source,
             distorted,
             frame_threads,
+            start,
+            frames,
             increment,
             graph,
             verbose,
@@ -135,6 +147,8 @@ fn main() {
                 &source,
                 &distorted,
                 frame_threads,
+                start,
+                frames,
                 inc,
                 graph,
                 verbose,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ struct Cli {
 }
 
 #[derive(Subcommand, Debug)]
+#[allow(clippy::large_enum_variant)]
 enum Commands {
     /// Compare two still images. Resolutions must be identical.
     Image {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,16 +43,14 @@ enum Commands {
 
         /// How many worker threads to use for decoding & calculating scores.
         /// Note: Memory usage increases linearly with the number of workers.
-        #[arg(long, short)]
+        #[arg(long, short, verbatim_doc_comment)]
         frame_threads: Option<usize>,
 
-        /// Frame to start comparison at.
-        /// 
-        #[arg(long, short, default_value_t = 0)]
-        start: usize,
+        /// The amount of frames to skip.
+        #[arg(long, default_value_t = 0)]
+        skip_frames: usize,
 
-        /// How many frames to compare.
-        /// If left unspecified, all frames will be compared.
+        /// Limit the amount of frames to compare.
         #[arg(long)]
         frames: Option<usize>,
 
@@ -110,7 +108,7 @@ fn main() {
             source,
             distorted,
             frame_threads,
-            start,
+            skip_frames,
             frames,
             increment,
             graph,
@@ -148,7 +146,7 @@ fn main() {
                 &source,
                 &distorted,
                 frame_threads,
-                start,
+                skip_frames,
                 frames,
                 inc,
                 graph,

--- a/src/video.rs
+++ b/src/video.rs
@@ -135,7 +135,7 @@ fn calc_score<S: Pixel, D: Pixel, E: Decoder, F: Decoder>(
     let (frame_idx, (src_frame, dst_frame)) = {
         let mut guard = mtx.lock().unwrap();
 
-        let skip_frames = guard.next_frame - guard.current_frame;
+        let distance_to_next = guard.next_frame - guard.current_frame;
 
         if let Some(end_frame) = end_frame {
             if guard.next_frame >= end_frame {
@@ -143,7 +143,7 @@ fn calc_score<S: Pixel, D: Pixel, E: Decoder, F: Decoder>(
             }
         }
 
-        for ii in 1..skip_frames {
+        for ii in 1..distance_to_next {
             let _src_frame = guard.source.read_video_frame::<S>();
             let _dst_frame = guard.distorted.read_video_frame::<D>();
             if _src_frame.is_none() || _dst_frame.is_none() {

--- a/src/video.rs
+++ b/src/video.rs
@@ -115,8 +115,10 @@ fn pretty_spinner_style() -> ProgressStyle {
         .progress_chars(PROGRESS_CHARS)
 }
 
+type VideoCompareMutex<E, F> = Mutex<((usize, usize), (E, F))>;
+
 fn calc_score<S: Pixel, D: Pixel, E: Decoder, F: Decoder>(
-    mtx: &Mutex<((usize, usize), (E, F))>,
+    mtx: &VideoCompareMutex<E, F>,
     src_yuvcfg: &YuvConfig,
     dst_yuvcfg: &YuvConfig,
     inc: usize,
@@ -404,13 +406,7 @@ fn compare_videos_inner<D: Decoder + 'static, E: Decoder + 'static>(
 
     let current_frame = 0usize;
     let start_frame = start_frame.unwrap_or(0);
-    let end_frame = {
-        if let Some(frames_to_compare) = frames_to_compare {
-            Some(start_frame + (frames_to_compare * inc))
-        } else {
-            None
-        }
-    };
+    let end_frame = frames_to_compare.map(|frames_to_compare| start_frame + (frames_to_compare * inc));
 
     let decoders = Arc::new(Mutex::new(((start_frame, current_frame), (source, distorted))));
 

--- a/src/video.rs
+++ b/src/video.rs
@@ -481,7 +481,7 @@ fn compare_videos_inner<D: Decoder + 'static, E: Decoder + 'static>(
         let frame_count = source_frame_count.or(distorted_frame_count);
         let pb = if let Some(frame_count) = frame_count {
             let fc = frames_to_compare.unwrap_or(frame_count - start_frame)
-                .min((frame_count as f64 / inc as f64).ceil() as usize);
+                .min(((frame_count - start_frame) as f64 / inc as f64).ceil() as usize);
 
             ProgressBar::new(fc as u64)
                 .with_style(pretty_progress_style())

--- a/src/video.rs
+++ b/src/video.rs
@@ -190,7 +190,7 @@ pub fn compare_videos(
     source: &str,
     distorted: &str,
     frame_threads: usize,
-    start_frame: Option<usize>,
+    start_frame: usize,
     frames_to_compare: Option<usize>,
     inc: usize,
     graph: bool,
@@ -323,7 +323,7 @@ fn compare_videos_inner<D: Decoder + 'static, E: Decoder + 'static>(
     source_frame_count: Option<usize>,
     distorted_frame_count: Option<usize>,
     frame_threads: usize,
-    start_frame: Option<usize>,
+    start_frame: usize,
     frames_to_compare: Option<usize>,
     inc: usize,
     graph: bool,
@@ -346,7 +346,7 @@ fn compare_videos_inner<D: Decoder + 'static, E: Decoder + 'static>(
     }
 
 
-    if start_frame.is_some() {
+    if start_frame != 0 {
         assert!(
             source_frame_count.is_some() || distorted_frame_count.is_some(),
             "--start-frame was used, but we could not get source or distorted frame count"
@@ -408,7 +408,6 @@ fn compare_videos_inner<D: Decoder + 'static, E: Decoder + 'static>(
     let dst_bd = dst_config.bit_depth;
 
     let current_frame = 0usize;
-    let start_frame = start_frame.unwrap_or(0);
     let end_frame = frames_to_compare
         .map(|frames_to_compare| start_frame + (frames_to_compare * inc));
 


### PR DESCRIPTION
Adds two new arguments:
- ~~`-s (--start)` sets the frame to start the comparison process at. 0 is the first frame.~~
  - Renamed: `--skip-frames` sets the amount of frames to skip.
- `--frames` The amount of frames (in total) to compare.

Also adjusts the progress bar to only count the amount of frames that get computed.

### Todo
- [x] Fix compatibility with  large `--increment` arg values
- [x] Clippy errors

Closes #19 