### PR TITLE
Change rolling average window to all frames

### DIFF
--- a/src/video.rs
+++ b/src/video.rs
@@ -1,4 +1,3 @@
-use std::cmp::min;
 use std::collections::BTreeMap;
 use std::io::stderr;
 use std::sync::{mpsc, Arc, Mutex};
@@ -483,15 +482,15 @@ fn compare_videos_inner<D: Decoder + 'static, E: Decoder + 'static>(
     };
 
     let mut results = BTreeMap::new();
-    let mut avg = 0f64;
+    let mut rolling_mean = 0f64;
     for score in result_rx {
         if verbose {
             println!("Frame {}: {:.8}", score.0, score.1);
         }
 
         results.insert(score.0, score.1);
-        avg = avg + (score.1 - avg) / (min(results.len(), 10) as f64);
-        progress.set_message(format!(", avg: {:.1$}", avg, 2));
+        rolling_mean = rolling_mean + (score.1 - rolling_mean) / (results.len() as f64);
+        progress.set_message(format!(", mean: {:.1$}", rolling_mean, 2));
         progress.inc(1);
     }
 

--- a/src/video.rs
+++ b/src/video.rs
@@ -490,7 +490,7 @@ fn compare_videos_inner<D: Decoder + 'static, E: Decoder + 'static>(
 
         results.insert(score.0, score.1);
         rolling_mean = rolling_mean + (score.1 - rolling_mean) / (results.len() as f64);
-        progress.set_message(format!(", mean: {:.1$}", rolling_mean, 2));
+        progress.set_message(format!(", mean: {rolling_mean:.2}"));
         progress.inc(1);
     }
 


### PR DESCRIPTION
This changes the average window to all frames, instead of the last 10 frames.
I believe this to be better than before, because the average wont be impacted as much. It should give the user a more meaningful insight on overall quality during computation.

The value is also essentially the mean, so I have renamed it.